### PR TITLE
When building OCIO extract the zip from the location we downloaded it to

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -374,7 +374,7 @@ def install_OpenImageIO(
         if not exists(OpenImageIO_installer):
             download(url, directory)
 
-        with cd(STORAGE_DIRECTORY):
+        with cd(directory):
             run('unzip {0}'.format(OpenImageIO_installer))
 
         with cd(OpenImageIO_directory):

--- a/fabfile.py
+++ b/fabfile.py
@@ -33,7 +33,7 @@ __all__ = [
 VAGRANT_DIRECTORY = '/vagrant'
 HOME_DIRECTORY = '/home/vagrant'
 SCRIPTS_DIRECTORY = posixpath.join(VAGRANT_DIRECTORY, 'scripts')
-STORAGE_DIRECTORY = posixpath.join(VAGRANT_DIRECTORY, 'tmp')
+STORAGE_DIRECTORY = '/tmp'
 
 BASH_PROFILE_FILE = posixpath.join(HOME_DIRECTORY, '.bash_profile')
 


### PR DESCRIPTION
There is no guarantee that the global variable will be correct if say a
caller supplied their own parameter for the location. So instead use the
correct variable!

Signed-off-by: Kevin Wheatley <kevin.j.wheatley@gmail.com>